### PR TITLE
Bump grpcio for Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,8 +43,10 @@ typing_extensions==4.11.0
 urllib3==2.2.1
 virtualenv==20.26.1
 xrpl-py==2.5.0
-grpcio==1.64.0
-grpcio-tools==1.64.0
+grpcio==1.64.0;python_version<"3.13"
+grpcio==1.66.2;python_version>="3.13"
+grpcio-tools==1.64.0;python_version<"3.13"
+grpcio-tools==1.66.2;python_version>="3.13"
 GitPython==3.1.43
 docker==7.1.0
 loguru==0.7.2


### PR DESCRIPTION
Bump grpcio to 1.66.2 for Python 3.13 environments to allow for their usage.

The grpcio packages started supporting Python 3.13 from [1.66.2](https://github.com/grpc/grpc/releases/tag/v1.66.2) onwards, 1.64.0 cannot compile for Python 3.13.