### PR TITLE
Fix race condition when a new iteration is started.

### DIFF
--- a/rocket_controller/ledger_result.py
+++ b/rocket_controller/ledger_result.py
@@ -55,6 +55,7 @@ class LedgerResult:
                 logger.error(
                     f"Could not fetch ledger {ledger_seq} from port {ws_port}."
                 )
+                logger.debug(f"Response from {ws_port}:\n{ledger_response}")
                 return None
             return ledger_response.result.get("ledger")
 


### PR DESCRIPTION
This PR fixes an issue where `all(ledger_seqs > x)` would return true when a new iteration is started. The standard behavior of `all(x)` is to return True if x is empty, which caused the program to start multiple new iterations without actually completing them, resulting in errors while running the spec checker. 