### PR TITLE
Implemented trace abstraction, refactor abstraction logic

### DIFF
--- a/plot_coverage.py
+++ b/plot_coverage.py
@@ -1,0 +1,18 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+
+CUR_RUN = "2025_09_07_13h37m"
+
+file_path = f"./logs/{CUR_RUN}/state_coverage.csv"
+df = pd.read_csv(file_path)
+
+plt.figure(figsize=(8, 5))
+plt.plot(df["iteration"], df["unique_states"], marker="o")
+
+# Paper uses log-scale for x-axis. (Learning-based controlled concurrency testing [https://dl.acm.org/doi/pdf/10.1145/3428298])
+plt.xscale("log", base=2)
+plt.xlabel("Iteration")
+plt.ylabel("Unique States")
+plt.title("Unique States vs Iteration")
+plt.grid(True)
+plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,4 @@ base58~=2.1.1
 cryptography~=42.0.7
 PyYAML~=6.0.1
 typeguard~=4.3.0
-
-grpcio~=1.66.2
 deap~=1.4.3

--- a/rocket_controller/csv_logger.py
+++ b/rocket_controller/csv_logger.py
@@ -46,7 +46,7 @@ transaction_log_columns = [
     "receiver account alias",
     "amount",
     "tx_hash",
-    "validated"
+    "validated",
 ]
 
 ledger_log_columns = [
@@ -54,21 +54,22 @@ ledger_log_columns = [
     "peer_id",
     "validated",
     "ledger_hash",
-    "transactions"
+    "transactions",
 ]
 
 tx_proposals_log_columns = [
     "sender_peer_id",
     "receiver_peer_id",
     "tx_hash",
-    "next_ledger_seq"
+    "next_ledger_seq",
 ]
 
-account_log_columns = [
-    "peer_id",
-    "account_alias",
-    "account_address",
-    "balance"
+account_log_columns = ["peer_id", "account_alias", "account_address", "balance"]
+
+state_coverage_log_columns = [
+    "iteration",
+    "unique_states",
+    "timestamp",
 ]
 
 
@@ -197,12 +198,20 @@ class ActionLogger(CSVLogger):
         # Note: timestamp is milliseconds since epoch (January 1, 1970)
         self.log_row(
             [
-                datetime.fromtimestamp(datetime.now().timestamp()).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+                datetime.fromtimestamp(datetime.now().timestamp()).strftime(
+                    "%Y-%m-%d %H:%M:%S.%f"
+                )[:-3]
                 if custom_timestamp is None
-                else datetime.fromtimestamp(custom_timestamp/1000).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3],
-                datetime.fromtimestamp(datetime.now().timestamp()).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+                else datetime.fromtimestamp(custom_timestamp / 1000).strftime(
+                    "%Y-%m-%d %H:%M:%S.%f"
+                )[:-3],
+                datetime.fromtimestamp(datetime.now().timestamp()).strftime(
+                    "%Y-%m-%d %H:%M:%S.%f"
+                )[:-3]
                 if sent_timestamp is None
-                else datetime.fromtimestamp(sent_timestamp/1000).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3],
+                else datetime.fromtimestamp(sent_timestamp / 1000).strftime(
+                    "%Y-%m-%d %H:%M:%S.%f"
+                )[:-3],
                 action,
                 send_amount,
                 from_node_id,
@@ -327,14 +336,11 @@ class SpecCheckLogger(CSVLogger):
                 ]
             )
 
+
 class TransactionLogger(CSVLogger):
     """CSVLogger child class dedicated to handling transaction validation logging."""
 
-    def __init__(
-            self,
-            sub_directory: str,
-            iteration: int
-    ):
+    def __init__(self, sub_directory: str, iteration: int):
         """
         Initialize TransactionLogger class.
 
@@ -350,13 +356,13 @@ class TransactionLogger(CSVLogger):
         self._lock = threading.Lock()
 
     def log_transaction_validation(
-            self,
-            node_id: int,
-            sender_alias: str,
-            receiver_alias: str,
-            amount: int,
-            tx_hash: str,
-            validated: bool,
+        self,
+        node_id: int,
+        sender_alias: str,
+        receiver_alias: str,
+        amount: int,
+        tx_hash: str,
+        validated: bool,
     ):
         """
         Log a transaction validation row to the CSV file.
@@ -372,22 +378,13 @@ class TransactionLogger(CSVLogger):
         with self._lock:
             with open(self.filepath, mode="a", newline="") as file:
                 writer = csv.writer(file)
-                writer.writerow([
-                    node_id,
-                    sender_alias,
-                    receiver_alias,
-                    amount,
-                    tx_hash,
-                    validated
-                ])
+                writer.writerow(
+                    [node_id, sender_alias, receiver_alias, amount, tx_hash, validated]
+                )
 
 
 class LedgerLogger(CSVLogger):
-    def __init__(
-            self,
-            sub_directory: str,
-            iteration: int
-    ):
+    def __init__(self, sub_directory: str, iteration: int):
         """
         Initialize LedgerLogger class.
 
@@ -403,12 +400,12 @@ class LedgerLogger(CSVLogger):
         self._lock = threading.Lock()
 
     def log_transaction_set(
-            self,
-            ledger_seq: int | str,
-            peer_id: int,
-            validated: bool,
-            ledger_hash: str,
-            txs: list[str],
+        self,
+        ledger_seq: int | str,
+        peer_id: int,
+        validated: bool,
+        ledger_hash: str,
+        txs: list[str],
     ):
         """
         Log a transaction validation row to the CSV file.
@@ -423,21 +420,11 @@ class LedgerLogger(CSVLogger):
         with self._lock:
             with open(self.filepath, mode="a", newline="") as file:
                 writer = csv.writer(file)
-                writer.writerow([
-                    ledger_seq,
-                    peer_id,
-                    validated,
-                    ledger_hash,
-                    txs
-                ])
+                writer.writerow([ledger_seq, peer_id, validated, ledger_hash, txs])
 
 
 class TXProposalLogger(CSVLogger):
-    def __init__(
-            self,
-            sub_directory: str,
-            iteration: int
-    ):
+    def __init__(self, sub_directory: str, iteration: int):
         """
         Initialize TXProposalLogger class.
 
@@ -453,11 +440,11 @@ class TXProposalLogger(CSVLogger):
         self._lock = threading.Lock()
 
     def log_proposal(
-            self,
-            sender_peer_id: int,
-            receiver_peer_id: int,
-            tx_hash: str,
-            next_ledger_seq: int
+        self,
+        sender_peer_id: int,
+        receiver_peer_id: int,
+        tx_hash: str,
+        next_ledger_seq: int,
     ):
         """
         Log a transaction validation row to the CSV file.
@@ -468,20 +455,11 @@ class TXProposalLogger(CSVLogger):
             tx_hash: hash of transaction
             next_ledger_seq: next up ledger sequence
         """
-        self.log_row([
-            sender_peer_id,
-            receiver_peer_id,
-            tx_hash,
-            next_ledger_seq
-        ])
+        self.log_row([sender_peer_id, receiver_peer_id, tx_hash, next_ledger_seq])
 
 
 class AccountLogger(CSVLogger):
-    def __init__(
-            self,
-            sub_directory: str,
-            iteration: int
-    ):
+    def __init__(self, sub_directory: str, iteration: int):
         """
         Initialize ProposalLogger class.
 
@@ -497,11 +475,7 @@ class AccountLogger(CSVLogger):
         self._lock = threading.Lock()
 
     def log_account_info(
-            self,
-            peer_id: int,
-            account_alias: str,
-            account_address,
-            balance: int
+        self, peer_id: int, account_alias: str, account_address, balance: int
     ):
         """
         Log a transaction validation row to the CSV file.
@@ -512,9 +486,31 @@ class AccountLogger(CSVLogger):
             account_address: address of the account
             balance: the balance
         """
-        self.log_row([
-            peer_id,
-            account_alias,
-            account_address,
-            balance
-        ])
+        self.log_row([peer_id, account_alias, account_address, balance])
+
+
+class StateCoverageLogger(CSVLogger):
+    def __init__(self, sub_directory: str):
+        """
+        Initialize StateCoverageLogger class.
+
+        Args:
+            sub_directory: The subdirectory to store the state coverage results in.
+            iteration: Current iteration number
+        """
+        super().__init__(
+            filename="state_coverage.csv",
+            columns=state_coverage_log_columns,
+            directory=sub_directory,
+        )
+        self._lock = threading.Lock()
+
+    def log_state_coverage(self, iteration: int, unique_states: int, timestamp: float):
+        """
+        Log a state coverage row to the CSV file.
+
+        Args:
+            iteration: Current iteration number
+            unique_states: Number of unique states
+        """
+        self.log_row([iteration, unique_states, timestamp])

--- a/rocket_controller/iteration_type.py
+++ b/rocket_controller/iteration_type.py
@@ -75,6 +75,7 @@ class TimeBasedIteration:
 
         self._byzantine_nodes = []
         self._on_new_iteration_callbacks = []
+        self._after_iteration_callbacks = []
 
         self._logged_once_8 = False
         self._logged_once_9 = False
@@ -84,9 +85,16 @@ class TimeBasedIteration:
         
     def register_callback(self, callback):
         self._on_new_iteration_callbacks.append(callback)
+    
+    def register_after_iteration_callback(self, callback):
+        self._after_iteration_callbacks.append(callback)
 
     def add_iteration_callbacks(self):
         for callback in self._on_new_iteration_callbacks:
+            callback()
+            
+    def add_after_iteration_callbacks(self):
+        for callback in self._after_iteration_callbacks:
             callback()
 
     def _stop_all(self):
@@ -349,6 +357,7 @@ class TimeBasedIteration:
 
         if self.cur_iteration > 1:
             self._spec_checker.spec_check(self.cur_iteration - 1, len(self._validator_nodes), self._max_ledger_seq, self._byzantine_nodes)
+            self.add_after_iteration_callbacks()
         if self.cur_iteration <= self._max_iterations:
             self._interceptor_manager.stop()
             self._ledger_results.new_result_logger(self._log_dir, self.cur_iteration)

--- a/rocket_controller/packet_server.py
+++ b/rocket_controller/packet_server.py
@@ -208,7 +208,7 @@ class PacketService(packet_pb2_grpc.PacketServiceServicer):
 
 def serve(strategy: Strategy):
     """This function starts the server and listens for incoming packets."""
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000000))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
     # TODO: should be unlimited messages in the queue which could be done by removing max_workers=10
     # However, this is still limited by the number of cores in your computer
     # And defaults to max_workers = min(32, (os.cpu_count() or 1) + 4) by ThreadPoolExecutor

--- a/rocket_controller/strategies/byzzql_strategy.py
+++ b/rocket_controller/strategies/byzzql_strategy.py
@@ -1,25 +1,199 @@
+import hashlib
 import random
-import sys
 import threading
 import time
-import hashlib
-from queue import Queue
-from typing import Tuple
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from queue import Empty, Queue
+from typing import Callable, Tuple
+
 from loguru import logger
 from xrpl.clients import JsonRpcClient
 
 from protos import packet_pb2, ripple_pb2
-from rocket_controller.strategies.strategy import Strategy
-from rocket_controller.strategies.byzzql_agent import ByzzQLAgent
 from rocket_controller.encoder_decoder import (
     DecodingNotSupportedError,
     PacketEncoderDecoder,
 )
-from rocket_controller.iteration_type import LedgerBasedIteration
 from rocket_controller.helper import MAX_U32
-from xrpl.core.binarycodec import decode
+from rocket_controller.iteration_type import LedgerBasedIteration
+from rocket_controller.strategies.byzzql_agent import ByzzQLAgent
+from rocket_controller.strategies.strategy import Strategy
 
 # TODO: check how we learn from the RL agent, how often we update the Q-values. Are most values 0.0 or not?
+
+
+class StateAbstraction(ABC):
+    def __init__(self) -> None:
+        self.message_queue = Queue()
+
+    def get_queue(self):
+        return self.message_queue
+
+    @abstractmethod
+    def get_hash(self) -> str:
+        pass
+
+    @abstractmethod
+    def reset(self):
+        pass
+
+    @abstractmethod
+    def run(
+        self,
+        rl_agent: ByzzQLAgent,
+        apply_action_callback: Callable,
+    ):
+        pass
+
+
+class MessageInboxAbstraction(StateAbstraction):
+    def __init__(self, params) -> None:
+        super().__init__()
+
+        # Fields for dynamic rate
+        self.sensitivity_ratio = float(params.get("sensitivity_ratio", 1.2))
+        self.target_inbox = int(params.get("target_inbox", 30))
+        self.overflow_factor = float(params.get("overflow_factor", 1.2))
+        self.underflow_factor = float(params.get("underflow_factor", 0.8))
+        self.max_events = int(params.get("max_events", 300))  # TODO: figure this out
+        self.r = self.max_events / 2
+
+    def get_hash(self):
+        """
+        For Inbox State Abstraction, use extracted key fields instead of just hashing the raw serialized
+        data to get a more meaningful state representation:
+        - TMProposeSet: proposeSeq, currentTxHash
+        - TMValidation: validation
+        - TMTransaction: rawTransaction
+        We sort, concatenate  and hash these extracted values from messages currently queued for
+        processing at each replica.
+        """
+        queue_contents = list(self.message_queue.queue)
+        extracted_values = [item[2] for item in queue_contents if item[2] is not None]
+        sorted_values = sorted(extracted_values)
+        concatenated = "|".join(sorted_values)
+        return hashlib.sha256(concatenated.encode()).hexdigest()
+
+    def reset(self):
+        # No manual reset needed between iterations
+        pass
+
+    def run(
+        self,
+        rl_agent: ByzzQLAgent,
+        apply_action_callback: Callable,
+    ):
+        # 1. Get message and apply collection delay
+        try:
+            packet, event, extracted_value, result_container = self.message_queue.get(
+                timeout=1.0
+            )
+        except Empty:
+            return
+
+        # Following code inspired by PriorityStrategy, with some small changes.
+        # Applies a dynamic dispatch rate as defined in http://doi.org/10.1109/ICSE-SEIP58684.2023.00009
+        inbox_size = self.message_queue.qsize()
+
+        # Adjust rate r based on inbox size
+        if inbox_size > self.target_inbox * self.overflow_factor:
+            self.r = min(self.r * self.sensitivity_ratio, inbox_size)
+        elif inbox_size < self.target_inbox * self.underflow_factor:
+            self.r = max(self.r / self.sensitivity_ratio, inbox_size / 6)
+        # else: r doesn't change
+
+        # Rate is clamped |events|/6 <= r <= |events|
+        self.r = int(max(inbox_size / 6, min(self.r, inbox_size)))
+
+        logger.debug(f"RATE {self.r}")
+
+        # Only apply rate if r is not zero
+        if self.r > 0:
+            interval = 1.0 / self.r
+            time.sleep(interval)
+
+        # 2. Now we have a collection window - make RL decision
+        current_state = self.get_hash()
+        action = rl_agent.choose_action(current_state)
+
+        # 3. Apply RL action (additional processing based on state)
+        apply_action_callback(action, packet, event, result_container)
+
+        # 4. Update RL learning
+        next_state = self.get_hash()
+        rl_agent.update_q_value(current_state, action, next_state)
+
+
+class TraceAbstraction(StateAbstraction):
+    def __init__(self) -> None:
+        super().__init__()
+
+        # Initialise trace_log as a dict that stores received messages per node (=per process)
+        self.trace_log: dict[int, list[str]] = defaultdict(list)
+
+    def record_event(self, node_port: int, extracted_value: str):
+        self.trace_log[node_port].append(extracted_value)
+
+    def get_hash(self) -> str:
+        concatenated = "|".join(
+            [
+                item
+                for node in sorted(self.trace_log.keys())
+                for item in self.trace_log[node]
+            ]
+        )
+        return hashlib.sha256(concatenated.encode()).hexdigest()
+
+    def get_hash_per_node(self, node_port: int) -> str:
+        concatenated = "|".join(self.trace_log[node_port])
+        return hashlib.sha256(concatenated.encode()).hexdigest()
+
+    def reset(self):
+        """
+        Resets the current trace log when dispatch thread is no longer active (in between iterations),
+        This needs to be done manually since the trace abstraction uses a seperate list, and not the queue (which is emptied by design).
+        """
+        for k, v in self.trace_log.items():
+            logger.debug(f"Trace Len {k}: {len(v)}")
+        self.trace_log = defaultdict(list)
+
+    def run(
+        self,
+        rl_agent: ByzzQLAgent,
+        apply_action_callback: Callable,
+    ):
+        try:
+            packet, event, extracted_value, result_container = self.message_queue.get(
+                timeout=1.0
+            )
+        except Empty:
+            return
+
+        # NOTE: It was unclear to me whether to implement the state hashing
+        # per process (node), or for the whole system, since it mentions 'per process'
+        # in the paper. However it would not be logical to do this, since QLearning needs
+        # information from the whole system to find bugs that arise from complex interactions
+        # between different nodes. The state space however is huge with this method.
+        # (but I guess that is expected from the 'trace' abstraction)
+        #
+        # I do keep the states for each process in a separate list, and combine them only for
+        # the hashing.
+        #
+        # current_state = self.get_hash_node(packet.to_port)
+        current_state = self.get_hash()
+
+        # RL agent chooses action based on current trace state
+        action = rl_agent.choose_action(current_state)
+
+        # Record action in the trace log and apply it
+        self.record_event(packet.to_port, extracted_value)
+        apply_action_callback(action, packet, event, result_container)
+
+        # Update Q-learning with new trace state
+        next_state = self.get_hash()
+        rl_agent.update_q_value(current_state, action, next_state)
+
 
 class ByzzQLStrategy(Strategy):
     def __init__(
@@ -30,7 +204,7 @@ class ByzzQLStrategy(Strategy):
         auto_parse_identical: bool = True,
         auto_parse_subsets: bool = True,
         keep_action_log: bool = True,
-        iteration_type = LedgerBasedIteration(10, 10, 65),
+        iteration_type=LedgerBasedIteration(10, 10, 65),
         log_dir: str | None = None,
         network_overrides=None,
         strategy_overrides=None,
@@ -48,38 +222,29 @@ class ByzzQLStrategy(Strategy):
             strategy_overrides,
         )
 
-        self.message_queue = Queue()
         self.running = True
+        self.dispatch_thread = threading.Thread(target=self.dispatch_loop, daemon=True)
 
-        # Fields for dynamic rate
-        self.sensitivity_ratio = float(self.params.get("sensitivity_ratio", 1.2))
-        self.target_inbox = int(self.params.get("target_inbox", 30))
-        self.overflow_factor = float(self.params.get("overflow_factor", 1.2))
-        self.underflow_factor = float(self.params.get("underflow_factor", 0.8))
-        self.max_events = int(self.params.get("max_events", 300))  # figure this out
-        self.r = self.max_events / 2
+        # Initialize RL Agent and State Abstraction
+        self.rl_agent = ByzzQLAgent(action_space=["DROP", "MUTATE", "DELIVER"])
+        self.state = TraceAbstraction()
 
         # Uncomment to silence the debug printouts
         # logger.remove()
         # logger.add(sys.stderr, level="INFO")  # or "WARNING" to silence info logs too
-
-        self.dispatch_thread = threading.Thread(target=self.dispatch_loop, daemon=True)
         self.clients = {}
-
         # Initialize RL agent
-        self.rl_agent = ByzzQLAgent(
-            action_space=["DROP", "MUTATE", "DELIVER"]
-        )
-        
+        self.rl_agent = ByzzQLAgent(action_space=["DROP", "MUTATE", "DELIVER"])
+
         # initialize process faults (mutations)
         self.iteration_type.register_callback(self.init_faults)
 
         self.old_proposals = []
         self.old_validations = []
-    
+
     def init_faults(self) -> None:
         self.process_faults_list = []
-        
+
         # for each round generate a random seed and use it for mutating messages,
         # this ensures that mutations are deterministic for each test run
         for i in range(1, self.iteration_type._max_ledger_seq + 1):
@@ -96,6 +261,7 @@ class ByzzQLStrategy(Strategy):
             self.running = False
             self.dispatch_thread.join()
             logger.info("Dispatch thread joined")
+        self.state.reset()
         self.running = True
         self.dispatch_thread = threading.Thread(target=self.dispatch_loop, daemon=True)
         self.dispatch_thread.start()
@@ -107,139 +273,122 @@ class ByzzQLStrategy(Strategy):
 
     def handle_packet(self, packet: packet_pb2.Packet) -> Tuple[bytes, int, int]:
         """Store message in queue and wait for dispatch"""
-        
+
         try:
             message, message_type_no = PacketEncoderDecoder.decode_packet(packet)
         except DecodingNotSupportedError:
-            logger.error(
-                f"Decoding of message is not supported"	)
-            return packet.data, 0, 1
-    
-        self.save_packet_for_mutation(message)
-        
-        # only process certain message types: TMValildation, TMProposeSet, TMTransaction
-        if not (isinstance(message, ripple_pb2.TMValidation) or
-                isinstance(message, ripple_pb2.TMProposeSet) or
-                isinstance(message, ripple_pb2.TMTransaction)):
+            logger.error("Decoding of message is not supported")
             return packet.data, 0, 1
 
+        self.save_packet_for_mutation(message)
+
+        # only process certain message types: TMValildation, TMProposeSet, TMTransaction
+        if not (
+            isinstance(message, ripple_pb2.TMValidation)
+            or isinstance(message, ripple_pb2.TMProposeSet)
+            or isinstance(message, ripple_pb2.TMTransaction)
+        ):
+            return packet.data, 0, 1
+
+        # Get receiving node's current round number
+        current_round = self.get_current_round_of_node(
+            self.network.port_to_id(packet.to_port)
+        )
+
+        # NOTE: The extracted value now only contains the message type and round number, I think this was
+        # discussed during the meeting as a way to simplify the state abstraction.
         extracted_value = None
         if isinstance(message, ripple_pb2.TMProposeSet):
-            extracted_value = f"ProposeSet:{packet.from_port}:{packet.to_port}:{message.proposeSeq}:{message.currentTxHash.hex()}"
+            # extracted_value = f"ProposeSet:{packet.from_port}:{packet.to_port}:{message.proposeSeq}:{message.currentTxHash.hex()}"
+            extracted_value = (
+                f"{current_round}-ProposeSet:{packet.from_port}:{packet.to_port}"
+            )
         elif isinstance(message, ripple_pb2.TMValidation):
             # We should use transactions here to extract values.
-            ledger_hash, transactions, validated, ledger_index = self.network.get_transactions('closed', self.network.port_to_id(packet.from_port))
-            extracted_value = f"Validation:{packet.from_port}:{packet.to_port}:{', '.join(transactions) if transactions else ''}"
+            # ledger_hash, transactions, validated, ledger_index = self.network.get_transactions('closed', self.network.port_to_id(packet.from_port))
+            # extracted_value = f"Validation:{packet.from_port}:{packet.to_port}:{', '.join(transactions) if transactions else ''}"
 
+            # extracted_value = f"Validation:{packet.from_port}:{packet.to_port}:{message.validation.hex()}"
+            extracted_value = (
+                f"{current_round}-Validation:{packet.from_port}:{packet.to_port}"
+            )
         elif isinstance(message, ripple_pb2.TMTransaction):
-            decoded = decode(message.rawTransaction.hex())
+            # decoded = decode(message.rawTransaction.hex())
             # Decoded TMTransaction: {'TransactionType': 'Payment', 'Flags': 0, 'Sequence': 2, 'LastLedgerSequence': 25, 'Amount': '100001000000', 'Fee': '10', 'SigningPubKey': '0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020', 'TxnSignature': '304402200BC25C59B3B22D01B9563D5CF0AB3ECD16B158916D885C26A60DA98CAE35757402207DEA9F34944AA7FAB26C8CC13FB9CD18A2F73EAF556CDEC6CCD0E216F4160A3D', 'Account': 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', 'Destination': 'rMAyDK9H3z3CM6YhTcdGCYUC2RGcDtaGCY'}
-            extracted_value = f"Transaction:{packet.from_port}:{packet.to_port}:{decoded['TransactionType']}:{decoded['Sequence']}:{decoded['Amount']}"
+            # extracted_value = f"Transaction:{packet.from_port}:{packet.to_port}:{decoded['TransactionType']}:{decoded['Sequence']}:{decoded['Amount']}"
+            extracted_value = (
+                f"{current_round}-Transaction:{packet.from_port}:{packet.to_port}"
+            )
 
         event = threading.Event()
         start_time = time.time()
         result_container = [packet.data, 0, 1]  # default: deliver
 
-        self.message_queue.put((packet, event, extracted_value, result_container))
-        queue_size = self.message_queue.qsize()
-        logger.debug(f"Queued packet from {packet.from_port} to {packet.to_port}, queue size: {queue_size}")
+        self.state.get_queue().put((packet, event, extracted_value, result_container))
+        queue_size = self.state.get_queue().qsize()
+        logger.debug(
+            f"Queued packet from {packet.from_port} to {packet.to_port}, queue size: {queue_size}"
+        )
         event.wait()
-        
+
         end_time = time.time()
         delay_ms = (end_time - start_time) * 1000
-        
-        logger.debug(f"Resumed packet from {packet.from_port} to {packet.to_port} after {delay_ms:.1f}ms delay")
+
+        logger.debug(
+            f"Resumed packet from {packet.from_port} to {packet.to_port} after {delay_ms:.1f}ms delay"
+        )
         return result_container[0], result_container[1], result_container[2]
 
     def dispatch_loop(self):
         while self.running:
-            try:
-                # 1. Get message and apply collection delay
-                packet, event, extracted_value, result_container = self.message_queue.get(timeout=1.0)
-
-                # Following code inspired by PriorityStrategy, with some small changes.
-                # Applies a dynamic dispatch rate as defined in http://doi.org/10.1109/ICSE-SEIP58684.2023.00009
-                inbox_size = self.message_queue.qsize()
-
-                # Adjust rate r based on inbox size
-                if inbox_size > self.target_inbox * self.overflow_factor:
-                    self.r = min(self.r * self.sensitivity_ratio, inbox_size)
-                elif inbox_size < self.target_inbox * self.underflow_factor:
-                    self.r = max(self.r / self.sensitivity_ratio, inbox_size / 6)
-                # else: r doesn't change
-
-                # Rate is clamped |events|/6 <= r <= |events|
-                self.r = int(max(inbox_size / 6, min(self.r, inbox_size)))
-
-                logger.debug(f"RATE {self.r}")
-
-                # Only apply rate if r is not zero
-                if self.r > 0:
-                    interval = 1.0 / self.r
-                    time.sleep(interval)
-
-                # 2. Now we have a collection window - make RL decision
-                current_state = self.get_inbox_state_hash()
-                action = self.rl_agent.choose_action(current_state)
-
-                # 3. Apply RL action (additional processing based on state)
-                self.apply_rl_action(action, packet, event, result_container)
-
-                # 4. Update RL learning
-                next_state = self.get_inbox_state_hash()
-                self.rl_agent.update_q_value(current_state, action, next_state)
-            except:
-                continue
-
-    def get_inbox_state_hash(self):
-        """
-        For Inbox State Abstraction, use extracted key fields instead of just hashing the raw serialized
-        data to get a more meaningful state representation:
-        - TMProposeSet: proposeSeq, currentTxHash
-        - TMValidation: validation
-        - TMTransaction: rawTransaction
-        We sort, concatenate  and hash these extracted values from messages currently queued for
-        processing at each replica.
-        """
-        queue_contents = list(self.message_queue.queue)
-        extracted_values = [item[2] for item in queue_contents if item[2] is not None]
-        sorted_values = sorted(extracted_values)
-        concatenated = "|".join(sorted_values)
-        return hashlib.sha256(concatenated.encode()).hexdigest()
+            # try:
+            self.state.run(
+                self.rl_agent,
+                self.apply_rl_action,
+            )
+        # except BaseException:
+        #     logger.debug()
+        #     continue
 
     def apply_rl_action(self, action, packet, event, result_container):
         peer_from_id = self.network.port_to_id(packet.from_port)
         peer_to_id = self.network.port_to_id(packet.to_port)
         if action == "DROP":
-            result_container[0] = packet.data 
-            result_container[1] = MAX_U32 
+            result_container[0] = packet.data
+            result_container[1] = MAX_U32
             result_container[2] = 1
-            logger.debug(f"RL Action: DROP - packet from {peer_from_id} to {peer_to_id} will be dropped.")
+            logger.debug(
+                f"RL Action: DROP - packet from {peer_from_id} to {peer_to_id} will be dropped."
+            )
             event.set()
         elif action == "MUTATE":
             if peer_from_id in self.iteration_type._byzantine_nodes:
                 # mutation logic
                 for round_num, seed in self.process_faults_list:
                     if round_num == self.get_current_round_of_node(peer_from_id):
-                        logger.debug(f"RL Action: MUTATE - packet from {peer_from_id} to {peer_to_id}, round: {self.get_current_round_of_node(peer_from_id)}.")
-                        mutated_data, delay, action_type = self.corrupt_message(packet, seed)
+                        logger.debug(
+                            f"RL Action: MUTATE - packet from {peer_from_id} to {peer_to_id}, round: {self.get_current_round_of_node(peer_from_id)}."
+                        )
+                        mutated_data, delay, action_type = self.corrupt_message(
+                            packet, seed
+                        )
                         result_container[0] = mutated_data
                         result_container[1] = delay
                         result_container[2] = action_type
                         event.set()
                         return
-            event.set() # else just deliver the message
+            event.set()  # else just deliver the message
             # TODO: it could happen that RL agent chooses action "mutate" and then we actually just deliver the message
-            # because the node is not byzantine, then in Q table we still store that action as "mutate". 
+            # because the node is not byzantine, then in Q table we still store that action as "mutate".
             # We can either store it as "deliver"or we can have two separate action spaces (one with MUTATE other without)
             # but then when choosing best action to take we would have to ignore MUTATE sometimes. Would this still be valid RL?
-        else:  
-            event.set() # default: deliver
+        else:
+            event.set()  # default: deliver
 
     def stop(self):
         self.running = False
         self.dispatch_thread.join()
-        
+
     def save_packet_for_mutation(self, message) -> None:
         if isinstance(message, ripple_pb2.TMProposeSet):
             self.old_proposals.append(message.currentTxHash)
@@ -252,12 +401,14 @@ class ByzzQLStrategy(Strategy):
             if node_id == _node_id:
                 return entry["seq"]
         return -1
-    
-    def corrupt_message(self, packet: packet_pb2.Packet, seed: int) -> tuple[bytes, int, int]:
+
+    def corrupt_message(
+        self, packet: packet_pb2.Packet, seed: int
+    ) -> tuple[bytes, int, int]:
         try:
             message, message_type_no = PacketEncoderDecoder.decode_packet(packet)
         except DecodingNotSupportedError:
-            logger.error(f"Decoding of message not supported")
+            logger.error("Decoding of message not supported")
             return packet.data, 0, 1
 
         if isinstance(message, ripple_pb2.TMProposeSet):
@@ -266,14 +417,18 @@ class ByzzQLStrategy(Strategy):
             return self._corrupt_TMValidation(message, message_type_no, seed)
         elif isinstance(message, ripple_pb2.TMTransaction):
             return self._corrupt_TMTransaction(message, message_type_no, seed)
-        
+
         return packet.data, 0, 1
 
-    def _corrupt_TMProposeSet(self, message, message_type_no: int, seed: int) -> tuple[bytes, int, int]:
+    def _corrupt_TMProposeSet(
+        self, message, message_type_no: int, seed: int
+    ) -> tuple[bytes, int, int]:
         rng = random.Random(seed)
-        if rng.choice([True, False]):  
+        if rng.choice([True, False]):
             logger.debug(f"Corrupting proposeSeq: {message.proposeSeq}")
-            message.proposeSeq += rng.choice([-1, 1])
+            # proposeSeq may never be below 0 (throws)
+            lower_bound = -1 if message.proposeSeq > 1 else 1
+            message.proposeSeq += rng.choice([lower_bound, 1])
             logger.debug(f"New proposeSeq: {message.proposeSeq}")
         else:
             logger.debug(f"Corrupting currentTxHash: {message.currentTxHash.hex()}")
@@ -283,19 +438,34 @@ class ByzzQLStrategy(Strategy):
         signed_message = PacketEncoderDecoder.sign_message(
             message, self.network.public_to_private_key_map[message.nodePubKey.hex()]
         )
-        return PacketEncoderDecoder.encode_message(signed_message, message_type_no), 0, 1
+        return (
+            PacketEncoderDecoder.encode_message(signed_message, message_type_no),
+            0,
+            1,
+        )
 
-    def _corrupt_TMValidation(self, message, message_type_no: int, seed: int) -> tuple[bytes, int, int]:
+    def _corrupt_TMValidation(
+        self, message, message_type_no: int, seed: int
+    ) -> tuple[bytes, int, int]:
         rng = random.Random(seed)
         logger.debug(f"Corrupting TMValidation: {message.validation.hex()}")
         message.validation = rng.choice(self.old_validations)
         logger.debug(f"New TMValidation: {message.validation.hex()}")
         return PacketEncoderDecoder.encode_message(message, message_type_no), 0, 1
 
-    def _corrupt_TMTransaction(self, message, message_type_no: int, seed: int) -> tuple[bytes, int, int]:
+    def _corrupt_TMTransaction(
+        self, message, message_type_no: int, seed: int
+    ) -> tuple[bytes, int, int]:
         rng = random.Random(seed)
-        logger.debug(f"Corrupting TMTransaction message which was {message.rawTransaction.hex()}")
-        transaction_hash_set = [tx[3] for tx in self.iteration_type.to_be_validated_txs] 
-        message.rawTransaction = self.iteration_type.reverse_compute_tx_hash(rng.choice(transaction_hash_set))
+        logger.debug(
+            f"Corrupting TMTransaction message which was {message.rawTransaction.hex()}"
+        )
+        transaction_hash_set = [tx[3] for tx in self.iteration_type.to_be_validated_txs]
+        # rng.choice throws on empty sequence, return original message (TODO: What should be correct behavior here?)
+        if not transaction_hash_set:
+            return PacketEncoderDecoder.encode_message(message, message_type_no), 0, 1
+        message.rawTransaction = self.iteration_type.reverse_compute_tx_hash(
+            rng.choice(transaction_hash_set)
+        )
         logger.debug(f"New TMTransaction message is {message.rawTransaction.hex()}")
         return PacketEncoderDecoder.encode_message(message, message_type_no), 0, 1


### PR DESCRIPTION
## Summary of Changes

### Refactoring of State Abstractions
Moved the logic concerned with state abstraction and QLearning to a designated `StateAbstraction` base class, `MessageInboxAbstraction` and `TraceAbstraction` inherit from this class, and its methods are called from the ByzzQL Strategy.

Note: I did not change any core logic of the `MessageInboxAbstraction`.

### Added TraceAbstraction

In every iteration, a `trace_log` is kept per node (process) in the network, which sequentially tracks the messages sent to this node. The hash of the state is calculated over the all of these `trace_logs` combined, from the start of the iteration to the current point in time. 

### Reduced State Space

I believe, according to the meeting with Burcu, for the TraceAbstraction it is sufficient if per message in (TMProposeSet, TMValidation, TMTransaction), to only track it's: Message Type, Sender ID, Receiver ID, and Round Number, in order to reduce the possible state space to a reasonable level. 

### Added Coverage Logging (In progress)

To make graphs of the coverage obtained by the various State Abstractions I log the amount of unique states discovered by the QLearning algorithm to a CSV file. I created a simple script in `plot_coverage.py`, that reads the file and plots the results.
