### PR TITLE
added 2 action spaces

### DIFF
--- a/rocket_controller/strategies/byzzql_agent.py
+++ b/rocket_controller/strategies/byzzql_agent.py
@@ -24,17 +24,23 @@ class ByzzQLAgent:
         
         # Q-table: initial values are 0.0 for each state-action pair
         self.q_table = defaultdict(lambda: {action: 0.0 for action in self.action_space}) 
+    
+    def choose_action(self, state_hash: str, available_action_space: List[str] = None) -> str:
+        # Use provided action space or fall back to default
+        action_space_to_use = available_action_space if available_action_space else self.action_space
         
-    def choose_action(self, state_hash: str) -> str:
         if random.random() < self.epsilon:
             # exploration
-            action = random.choice(self.action_space)
-            logger.debug(f"RL Agent: Exploring with random action '{action}'")
+            action = random.choice(action_space_to_use)
+            logger.debug(f"RL Agent: Exploring with random action '{action}' from {action_space_to_use}")
         else:
-            # exploitation: choose best action based on Q-table
+            # exploitation: choose best action from available actions based on Q-table
             q_values = self.q_table[state_hash]
-            max_q_value = max(q_values.values())
-            best_actions = [action for action, q_val in q_values.items() if q_val == max_q_value]
+            # Filter Q-values to only include available actions
+            available_q_values = {action: q_val for action, q_val in q_values.items() 
+                                if action in action_space_to_use}
+            max_q_value = max(available_q_values.values())
+            best_actions = [action for action, q_val in available_q_values.items() if q_val == max_q_value]
             action = random.choice(best_actions)  # break ties randomly
             logger.debug(f"RL Agent: Exploiting with action '{action}' (Q={max_q_value:.3f})")
         return action


### PR DESCRIPTION
- Because message mutations only applies to Byzantine nodes, we now have two separate action spaces (one with "mutate" action and other without it). If node sender is Byzantine and node receiver is in receiver_subset, then we choose action space with "mutate" otherwise we choose one without it.

- Now we pre-determine process faults with the round number, a corresponding seed and receiver_subset creating a list of <round, seed, receiver_subset>. Thus for each round mutations are applied deterministically. While actually handling messages, we would first check if the sender node is Byzantine and whether for that specific round there exists at least one subset containing the receiver node. Only then would we use an action space that includes "mutate" and if "mutate" action is chosen, apply mutation with corresponding seed.